### PR TITLE
Use with eventmachine 1.0.0

### DIFF
--- a/em-serialport.gemspec
+++ b/em-serialport.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.executables   = ['serial-monitor']
   s.require_paths = ["lib"]
 
-  s.add_dependency "eventmachine", "0.12.10"
+  s.add_dependency "eventmachine", "1.0.0"
   s.add_dependency "serialport"
 end

--- a/lib/em-serialport.rb
+++ b/lib/em-serialport.rb
@@ -1,5 +1,5 @@
 $eventmachine_library = :pure_ruby
-require 'eventmachine'
+require 'em/pure_ruby'
 require 'serialport'
 
 %w(serial_port connection).each do |file|

--- a/lib/em-serialport/version.rb
+++ b/lib/em-serialport/version.rb
@@ -1,5 +1,5 @@
 module Em
   module Serialport
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end


### PR DESCRIPTION
In order to avoid gcc errors in debian wheezy, event machine must be >= 1.0.0. I changed the code (not a lot ;) ) in order to make it work (no tests done but it's working without any issue for two days on my raspberry pi)

Bump version of eventmachine to "1.0.0"
Update lib/em-serialport.rb to make it work with eventmachine > 0.12.10 in pure ruby mode
Update version number
